### PR TITLE
ci: add PR build check and verify /eakbg-planer/ route

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,6 +15,9 @@ jobs:
                   npm ci
                   npm run build
 
+            - name: Verify /eakbg-planer/ built
+              run: test -f dist/eakbg-planer/index.html
+
             - name: 📂 Deploy via rsync
               uses: burnett01/rsync-deployments@v8
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on:
+    pull_request:
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout 🛎️
+              uses: actions/checkout@v4
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+                  cache: 'npm'
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Build
+              run: npm run build
+
+            - name: Verify /eakbg-planer/ built
+              run: test -f dist/eakbg-planer/index.html


### PR DESCRIPTION
## Summary

Adds CI coverage so a broken `/eakbg-planer/` page (the interactive Svelte 5 island in `src/lib/components/EaKbgPlaner.svelte`) is caught **before** it lands on `main`.

Two changes:

1. **New workflow `.github/workflows/ci.yml`** — runs `npm ci && npm run build` on every pull request. Today the existing `build-and-deploy.yml` only triggers on `push` to `main`, so a PR that breaks the build would only fail *after* merging. This closes that gap.
2. **Route-existence guard** — both workflows now run `test -f dist/eakbg-planer/index.html` after the build. Catches silent regressions like a removed `client:load`, renamed route, or accidental import drop that wouldn't fail the build itself.

## What this catches
- Build failures (TS/Svelte compile errors, missing imports, broken Astro integrations) on PRs
- The `/eakbg-planer/` route silently disappearing from the build output
- Same guarantees apply to deploys to production

## What this does NOT catch
- Runtime hydration errors (would need Playwright)
- Logic bugs in the planner's date/timeline math (would need Vitest)

These could be added later if needed — see chat thread for the full comparison of build smoke / Vitest / Playwright options.

## Note on `npm run check`
I considered also adding `npm run check` (astro check / TS) to CI, but it currently fails on a pre-existing, unrelated error in `src/utils/permalinks.ts:40`:

```
ts(2367): This comparison appears to be unintentional because the types 'true' and 'false' have no overlap.
```

Adding `npm run check` here would make CI red on day one. Worth fixing in a separate PR and then wiring it into both workflows.

## Test plan
- [ ] PR opens with green CI (build + route check)
- [ ] Verify the `Verify /eakbg-planer/ built` step appears in the workflow run
- [ ] After merge, confirm `build-and-deploy.yml` still deploys as before
- [ ] (Optional manual check) Temporarily rename `src/pages/eakbg-planer.astro` on a throwaway branch → CI should fail at the verify step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7AZqtdsp1bZwTk2JdhB6H)_