### PR TITLE
fix(permalinks): widen SITE.trailingSlash type so `astro check` passes

### DIFF
--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -4,11 +4,11 @@ import { trim } from '~/utils/utils';
 
 // Site config (previously from src/config.yaml via astrowind:config).
 // Must agree with astro.config.ts `site` + `trailingSlash`.
-const SITE = {
+const SITE: { site: string; base: string; trailingSlash: boolean } = {
   site: 'https://karenz-wizard.at',
   base: '/',
   trailingSlash: true,
-} as const;
+};
 
 export const trimSlash = (s: string) => trim(trim(s, '/'));
 const createPath = (...params: string[]) => {


### PR DESCRIPTION
## Summary

Fixes the only error reported by `npm run check`:

```
src/utils/permalinks.ts:40:7 - error ts(2367):
This comparison appears to be unintentional because the types 'true' and 'false' have no overlap.

40   if (SITE.trailingSlash == false && path && url.endsWith('/')) {
```

## Root cause

`SITE` was declared `as const`, so `trailingSlash: true` was narrowed to the literal type `true`. That made the `== false` branch in `getCanonical` provably unreachable, which is what TS was flagging.

The `as const` was added when `SITE` was inlined (the comment notes it "previously from src/config.yaml"). Before that, the value came from yaml and was typed as a regular `boolean`, so both branches type-checked.

## Fix

Type `SITE` explicitly with a `boolean` field instead of using `as const`. Smallest possible change, restores the original typing intent, no runtime behavior change.

```diff
-const SITE = {
+const SITE: { site: string; base: string; trailingSlash: boolean } = {
   site: 'https://karenz-wizard.at',
   base: '/',
   trailingSlash: true,
-} as const;
+};
```

## Verification

- `npm run check` → **0 errors** (was 1)
- `npm run build` → still succeeds, 39 pages built
- No call sites change behavior (`getCanonical` still returns the same URL string at runtime since `trailingSlash` is still `true`)

## Follow-up

Once this lands, the CI workflow added in #10 can be extended to also run `npm run check` as a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7AZqtdsp1bZwTk2JdhB6H)_