### PR TITLE
test(e2e): Playwright smoke test for EaKbgPlaner island buttons

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,50 @@
+name: E2E
+on:
+    pull_request:
+
+jobs:
+    e2e:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - name: Checkout 🛎️
+              uses: actions/checkout@v4
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+                  cache: 'npm'
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Get Playwright version
+              id: pw
+              run: echo "version=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Playwright browsers
+              id: pw-cache
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+            - name: Install Playwright browsers
+              if: steps.pw-cache.outputs.cache-hit != 'true'
+              run: npx playwright install --with-deps chromium
+
+            - name: Install Playwright system deps (cache hit)
+              if: steps.pw-cache.outputs.cache-hit == 'true'
+              run: npx playwright install-deps chromium
+
+            - name: Run e2e tests
+              run: npm run test:e2e
+
+            - name: Upload Playwright report
+              if: failure()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-report
+                  path: playwright-report/
+                  retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 test-results
+playwright-report
+playwright/.cache
 node_modules
 
 # Output

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@astrojs/tailwind": "^5.1.5",
         "@iconify-json/flat-color-icons": "^1.2.1",
         "@iconify-json/tabler": "^1.2.20",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/forms": "^0.5.9",
         "@tailwindcss/typography": "^0.5.16",
         "@types/js-yaml": "^4.0.9",
@@ -661,6 +662,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1211,6 +1213,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1233,6 +1236,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1255,6 +1259,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1271,6 +1276,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1287,6 +1293,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1303,6 +1310,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1319,6 +1327,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1335,6 +1344,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1351,6 +1361,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1367,6 +1378,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1383,6 +1395,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1399,6 +1412,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1421,6 +1435,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1443,6 +1458,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1465,6 +1481,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1487,6 +1504,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1509,6 +1527,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1531,6 +1550,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1553,6 +1573,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1572,6 +1593,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1591,6 +1613,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1610,6 +1633,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1782,6 +1806,22 @@
         "@types/node": "22.13.14",
         "deepmerge-ts": "7.1.5",
         "fast-glob": "3.3.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@qwik.dev/partytown": {
@@ -5639,6 +5679,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5659,6 +5700,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5679,6 +5721,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5699,6 +5742,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5719,6 +5763,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5739,6 +5784,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5759,6 +5805,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5779,6 +5826,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5799,6 +5847,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5819,6 +5868,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7581,6 +7631,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "astro": "astro",
     "check": "astro check",
     "format": "prettier --write .",
-    "lint": "prettier --check ."
+    "lint": "prettier --check .",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.4.2",
@@ -36,6 +38,7 @@
     "@astrojs/tailwind": "^5.1.5",
     "@iconify-json/flat-color-icons": "^1.2.1",
     "@iconify-json/tabler": "^1.2.20",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/typography": "^0.5.16",
     "@types/js-yaml": "^4.0.9",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 4321;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+	testDir: './tests/e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+	use: {
+		baseURL: BASE_URL,
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+	webServer: {
+		command: `npm run build && npm run preview -- --port ${PORT}`,
+		url: BASE_URL,
+		timeout: 180_000,
+		reuseExistingServer: !process.env.CI,
+	},
+});

--- a/src/lib/components/EaKbgPlaner.svelte
+++ b/src/lib/components/EaKbgPlaner.svelte
@@ -927,7 +927,7 @@
 	const toX = (weeks: number) => margins.left + weeks * scale;
 </script>
 
-<section>
+<section data-testid="eakbg-planer">
 	<div class="example-presets mb-2 min-w-0">
 			<span>Beispiele:</span> 
 

--- a/tests/e2e/eakbg-planer-buttons.spec.ts
+++ b/tests/e2e/eakbg-planer-buttons.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect, type Locator } from '@playwright/test';
+
+// Smoke test: every visible, enabled button inside the EaKbgPlaner Svelte
+// island can be clicked without producing an uncaught JS exception. Buttons
+// outside the island (nav, footer, breadcrumbs) are intentionally excluded.
+
+test('EaKbgPlaner: clicking every island button raises no JS errors', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`));
+
+	await page.goto('/eakbg-planer/');
+
+	const island = page.getByTestId('eakbg-planer');
+	await expect(island).toBeVisible();
+
+	// Snapshot the initial set of buttons. We intentionally do not re-query
+	// after each click: clicking may add/remove buttons (e.g. opening a
+	// dialog), and stale handles correctly skip via isVisible/isEnabled.
+	const buttons = await island.getByRole('button').all();
+	expect(buttons.length, 'expected at least one button inside the island').toBeGreaterThan(0);
+
+	let clicked = 0;
+	let skipped = 0;
+	for (const btn of buttons) {
+		if (!(await safeIsActionable(btn))) {
+			skipped++;
+			continue;
+		}
+		const label = (await btn.textContent())?.trim().slice(0, 60) ?? '<no text>';
+		await btn.click({ timeout: 2000 }).catch((err) => {
+			errors.push(`click failed for "${label}": ${err.message}`);
+		});
+		clicked++;
+	}
+
+	console.log(`island buttons: clicked=${clicked} skipped=${skipped}`);
+	expect(errors, errors.join('\n') || 'no errors').toEqual([]);
+});
+
+async function safeIsActionable(btn: Locator): Promise<boolean> {
+	try {
+		return (await btn.isVisible()) && (await btn.isEnabled());
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

Adds a Playwright smoke test that loads `/eakbg-planer/`, finds every visible+enabled `<button>` **inside the EaKbgPlaner Svelte island**, clicks each one, and asserts no uncaught JS exceptions are raised.

Buttons outside the island (nav, footer, breadcrumb, "Optionale Sub-Schritte" links) are intentionally **excluded** — they're not part of the interactive component under test.

Follow-up to #10 (build smoke + route check). They cover different failure modes:
- **#10:** "does the page exist?"
- **this PR:** "does clicking anything in the planner blow up?"

## How it works

1. `data-testid="eakbg-planer"` added to the component's root `<section>` as a stable hook (one-character selector beats brittle CSS class chains).
2. Test scopes to that testid and iterates `getByRole('button')` inside it.
3. `pageerror` listener collects uncaught JS exceptions; assertion fails if any fire.
4. Skips buttons that are hidden or disabled (correctly — they're not user-actionable).

## Files

| File | Why |
|---|---|
| `.github/workflows/e2e.yml` | Runs on PRs. Caches Playwright browsers keyed on `@playwright/test` version (~30s saved per run after first). |
| `playwright.config.ts` | Builds + serves with `astro preview` on port 4321; chromium-only. |
| `tests/e2e/eakbg-planer-buttons.spec.ts` | The test itself (~40 lines). |
| `package.json` | Adds `test:e2e` and `test:e2e:ui` scripts, `@playwright/test` devDep. |
| `src/lib/components/EaKbgPlaner.svelte` | Added `data-testid="eakbg-planer"` to root `<section>`. |
| `.gitignore` | Excludes `playwright-report/`, `playwright/.cache/`. |

## Known design choices / caveats

- **`pageerror` only, not `console.error`.** Avoids noise from third-party scripts (Partytown, analytics) and Svelte deprecation warnings. Catches what we actually care about: uncaught runtime exceptions. Easy to widen later.
- **Button list is snapshotted before the loop.** Clicking can add/remove buttons in the DOM; we don't re-query, and stale handles correctly self-skip via `isVisible/isEnabled`.
- **No order/state assertions.** The test only proves "no click crashes" — not that clicks produce correct results. Detailed logic tests belong in Vitest unit tests against the rune state.
- **Order-dependent crashes are possible.** If clicking "remove segment" before "add segment" legitimately throws, the test will flag it. That's arguably correct (user-reachable state shouldn't crash), but if it becomes a maintenance burden, scope the loop to a stable subset of buttons.

## ⚠️ Not verified locally

This PR was authored in a sandbox where Playwright's browser CDN download is blocked, so I could only:
- ✅ Confirm the test is discovered (`npx playwright test --list`)
- ✅ Confirm `npm run build` still succeeds with the added `data-testid`
- ❌ **Could not actually run the test against a real Chromium**

The first CI run on this PR is therefore the real verification. If it fails, common likely causes:
1. The island contains buttons that legitimately throw on click out-of-order (see caveat above)
2. The `data-testid` selector misses (unlikely — it's on the root `<section>`)
3. Hydration warnings logged as `pageerror` (would be a real bug worth fixing)

## Test plan
- [ ] CI runs `e2e` job to green on this PR
- [ ] If red, inspect the `playwright-report` artifact to see which button broke
- [ ] Manual sanity check: temporarily throw inside a button handler in `EaKbgPlaner.svelte` on a throwaway commit → CI should fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7AZqtdsp1bZwTk2JdhB6H)_